### PR TITLE
use `fix-path` module to fix the $PATH on OS X

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ var debug = require('debug')('monu')
 var ipc = require('ipc')
 var shell = require('shell')
 
-// launching from .menu.app doesnt use bash and never loads .e.g. .bash_profile
-process.env.PATH = '/usr/local/bin:' + process.env.PATH
+// fix the $PATH on OS X
+require('fix-path')()
 
 var opts = {
   dir: __dirname,

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "atom-shell-packager": "^1.1.0",
     "debug": "^2.1.3",
+    "fix-path": "^1.0.0",
     "menubar": "^2.0.0",
     "mkdirp": "^0.5.0",
     "mongroup": "maxogden/node-mongroup#monbin",


### PR DESCRIPTION
because why not

might need improvements in the future and this way you won't have to care

https://github.com/sindresorhus/fix-path
