### PR TITLE
Fix license to the SPDX License format

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/maxogden/monu"
   },
   "author": "max ogden",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "dependencies": {
     "debug": "^2.1.3",
     "electron-rpc": "^1.0.0",


### PR DESCRIPTION
Fixes the following message:

<img width="637" alt="screen shot 2015-10-30 at 2 53 52 pm" src="https://cloud.githubusercontent.com/assets/432489/10856485/0f3b82a2-7f16-11e5-9866-98a282e2f452.png">

SPDX: http://spdx.org/licenses/BSD-2-Clause.html
